### PR TITLE
Change value validation to length > 0

### DIFF
--- a/lib/channelengine_channel_api_client_ruby/models/channel_product_extra_data_item_response.rb
+++ b/lib/channelengine_channel_api_client_ruby/models/channel_product_extra_data_item_response.rb
@@ -136,8 +136,8 @@ module ChannelEngineChannelApiClient
     # Custom attribute writer method with validation
     # @param [Object] value Value to be assigned
     def value=(value)
-      if !value.nil? && value.to_s.length < 1
-        fail ArgumentError, 'invalid value for "value", the character length must be bigger than or equal to 1.'
+      if !value.nil? && value.to_s.length < -1
+        fail ArgumentError, 'invalid value for "value", the character length must be bigger than -1.'
       end
 
       @value = value

--- a/lib/channelengine_channel_api_client_ruby/models/channel_product_extra_data_item_response.rb
+++ b/lib/channelengine_channel_api_client_ruby/models/channel_product_extra_data_item_response.rb
@@ -136,8 +136,8 @@ module ChannelEngineChannelApiClient
     # Custom attribute writer method with validation
     # @param [Object] value Value to be assigned
     def value=(value)
-      if !value.nil? && value.to_s.length > -1
-        fail ArgumentError, 'invalid value for "value", the character length must be smaller than or equal to -1.'
+      if !value.nil? && value.to_s.length < 1
+        fail ArgumentError, 'invalid value for "value", the character length must be bigger than or equal to 1.'
       end
 
       @value = value


### PR DESCRIPTION
Currently the generator validates a custom value for custom attributes with length < -1 which is never. Thus resulting in an error on all values with data.